### PR TITLE
drm: renesas: rz-du: Add missing DSI D-PHY init

### DIFF
--- a/drivers/gpu/drm/renesas/rz-du/rzg2l_mipi_dsi.c
+++ b/drivers/gpu/drm/renesas/rz-du/rzg2l_mipi_dsi.c
@@ -728,13 +728,14 @@ static int rzg2l_mipi_dsi_startup(struct rzg2l_mipi_dsi *dsi,
 	ret = pm_runtime_resume_and_get(dsi->dev);
 	if (ret < 0)
 		return ret;
+
 	if (dsi->info->type == MIPI_DSI_DPHY_RZV2H) {
 		clk_set_rate(dsi->vclk, mode->clock * 1000);
-	} else {
-		clk_set_rate(dsi->vclk, mode->clock);
-	}
 
-	ret = dsi->info->dphy_init(dsi, hsfreq);
+		ret = dsi->info->dphy_init(dsi, hsfreq);
+	} else {
+		ret = rzg2l_mipi_dsi_dphy_init(dsi, hsfreq);
+	}
 	if (ret < 0)
 		goto err_phy;
 


### PR DESCRIPTION
Ensure that `rzg2l_mipi_dsi_dphy_init()` is called during DSI startup for platforms that do not use the RZ/V2H-specific D-PHY handler.

Previously, the D-PHY initialization was skipped, resulting in a non-functional DSI interface. This commit restores the missing initialization path.