### PR TITLE
media: rzg2l-cru: use s_stream(0) to stop streaming in retry

### DIFF
--- a/drivers/media/platform/renesas/rzg2l-cru/rzg2l-video.c
+++ b/drivers/media/platform/renesas/rzg2l-cru/rzg2l-video.c
@@ -671,7 +671,7 @@ static int retry_streaming_func(void *data)
 
 		/* Stop CRU reception */
 		rzg2l_cru_write(cru, ICnEN, 0);
-		v4l2_subdev_call(sd, video, post_streamoff);
+		v4l2_subdev_call(sd, video, s_stream, 0);
 		rzg2l_cru_stop_image_processing(cru);
 		pm_runtime_put(cru->dev);
 		msleep(20);


### PR DESCRIPTION
Replace post_streamoff with s_stream(0) to ensure the camera subdevice is correctly stopped during retries.