### PR TITLE
rz-cmn: rs-g2l100: Fix error emmc init on rs-g2l100 board.

### DIFF
--- a/arch/arm64/boot/dts/renesas/rs-g2l100.dts
+++ b/arch/arm64/boot/dts/renesas/rs-g2l100.dts
@@ -769,6 +769,7 @@
 
 &sdhi0 {
     pinctrl-0 = <&sdhi0_emmc_pins>;
+    pinctrl-1 = <&sdhi0_emmc_pins>;
     pinctrl-names = "default", "state_uhs";
 
     vmmc-supply = <&reg_3p3v>;


### PR DESCRIPTION
Change include:
	- Fix error emmc init on rs-g2l100 board.