### PR TITLE
arm64: dts: renesas: Add mmc0,1 aliases for all RZ/[V,G]2L platforms

### DIFF
--- a/arch/arm64/boot/dts/renesas/rz-smarc-common.dtsi
+++ b/arch/arm64/boot/dts/renesas/rz-smarc-common.dtsi
@@ -26,6 +26,8 @@
 		serial0 = &scif0;
 		i2c0 = &i2c0;
 		i2c1 = &i2c1;
+		mmc0 = &sdhi0;
+		mmc1 = &sdhi1;
 	};
 
 	chosen {


### PR DESCRIPTION
```
Fix index of mmcblk devices:
aliases {
        mmc0 = &sdhi0;  /* mmcblk0 for eMMC */
        mmc1 = &sdhi1;  /* mmcblk1 for uSD */
};
```