### PR TITLE
rzv2h-rdk: fix hdmi audio and external video codec da7219

### DIFF
--- a/arch/arm64/boot/dts/renesas/overlays/rzv2h-rdk-1.0-audio-codec.dts
+++ b/arch/arm64/boot/dts/renesas/overlays/rzv2h-rdk-1.0-audio-codec.dts
@@ -1,50 +1,101 @@
 // SPDX-License-Identifier: GPL-2.0+
 /*
+ * Device Tree Overlay for DA7219 Audio Codec on RZ/V2H RDK ver1
  * Copyright (C) 2025 Renesas Electronics Corporation
  */
-
 /dts-v1/;
 /plugin/;
 
 #include <dt-bindings/pinctrl/rzv2h-pinctrl.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
 
-/ {
-    fragment@0 {
-        target = <&rcar_sound>;
-        __overlay__ {
-            pinctrl-0 = <&sound_pins>;
+&sound_card {
+    dais = <&rsnd_port0>;
+};
 
-            ports {
-                rsnd_port0: port@0 {
-                    rsnd_endpoint0: endpoint {
-                        remote-endpoint = <&da7219_endpoint>;
-                        mclk-fs = <256>;
-                    };
-                };
+&pinctrl {
+    sound_pins_codec: sound {
+        pinmux = <RZV2H_PORT_PINMUX(9, 5, 7)>,  /* SSI0_SCK */
+                 <RZV2H_PORT_PINMUX(9, 6, 7)>,  /* SSI0_WS */
+                 <RZV2H_PORT_PINMUX(9, 7, 7)>,  /* SSI0_SDATA */
+                 <RZV2H_PORT_PINMUX(A, 6, 7)>;  /* SSI9_SDATA */
+    };
+};
+
+&i2c3 {
+    adv7535: hdmi@3d {
+        ports {
+            port@2 { status = "disabled"; };
+        };
+    };
+};
+
+&rsci_i2c7 {
+    status = "okay";
+
+    da7219: da7219@1a {
+        compatible = "dlg,da7219";
+        #sound-dai-cells = <0>;
+        #address-cells = <1>;
+        #size-cells = <0>;
+        reg = <0x1a>;
+
+        dlg,micbias-lvl = <2600>;
+        dlg,mic-amp-in-sel = "diff";
+        VDD-supply = <&reg_1p8v>;
+        VDDMIC-supply = <&reg_3p3v>;
+        VDDIO-supply = <&reg_3p3v>;
+        clock-names = "mclk";
+        status = "okay";
+
+        interrupt-parent = <&pinctrl>;
+        interrupts = <RZV2H_GPIO(5, 1) IRQ_TYPE_LEVEL_LOW>;
+
+        da7219_aad {
+            dlg,btn-avg = <4>;
+            dlg,adc-1bit-rpt = <1>;
+            dlg,btn-cfg = <50>;
+            dlg,mic-det-thr = <500>;
+            dlg,jack-ins-deb = <20>;
+            dlg,jack-det-rate = "32_64";
+            dlg,jack-rem-deb = <1>;
+            dlg,a-d-btn-thr = <0xa>;
+            dlg,d-b-btn-thr = <0x16>;
+            dlg,b-c-btn-thr = <0x21>;
+            dlg,c-mic-btn-thr = <0x3E>;
+        };
+
+        port {
+            da7219_endpoint: endpoint {
+                remote-endpoint = <&rsnd_endpoint0>;
             };
         };
     };
+};
 
-    fragment@1 {
-        target = <&adv7535>;
-        __overlay__ {
-            status = "disabled";
-        };
-    };
+&rcar_sound {
+    pinctrl-0 = <&sound_pins_codec>;
 
-    fragment@2 {
-        target = <&rsci_i2c7>;
-        __overlay__ {
-            da7219: da7219@1a {
-                #address-cells = <1>;
-                #size-cells = <0>;
+    ports {
+        /* Add DA7219 port */
+        rsnd_port0: port@0 {
+            reg = <0>;
+            rsnd_endpoint0: endpoint {
+                remote-endpoint = <&da7219_endpoint>;
 
-                port {
-                    da7219_endpoint: endpoint {
-                        remote-endpoint = <&rsnd_endpoint0>;
-                    };
-                };
+                dai-format = "i2s";
+                bitclock-master = <&rsnd_endpoint0>;
+                frame-master = <&rsnd_endpoint0>;
+                mclk-fs = <256>;
+
+                playback = <&ssi0>;
+                capture = <&ssi9>;
             };
         };
     };
+};
+
+&ssi9 {
+    shared-pin;
 };

--- a/arch/arm64/boot/dts/renesas/rzv2h-rdk-ver1.dts
+++ b/arch/arm64/boot/dts/renesas/rzv2h-rdk-ver1.dts
@@ -237,7 +237,6 @@
         compatible = "audio-graph-card";
 
         label = "rcar-sound";
-
         dais = <&rsnd_port0>;
     };
 };
@@ -334,12 +333,6 @@
         pinmux = <RZV2H_PORT_PINMUX(4, 0, 7)>, /* SSI0_SCK */
              <RZV2H_PORT_PINMUX(4, 1, 7)>,     /* SSI0_WS */
              <RZV2H_PORT_PINMUX(4, 2, 7)>;     /* SSI0_SDATA */
-    };
-
-    sound_pins: sound {
-        pinmux = <RZV2H_PORT_PINMUX(9, 5, 7)>, /* SSI0_SCK */
-            <RZV2H_PORT_PINMUX(9, 6, 7)>,     /* SSI0_WS */
-            <RZV2H_PORT_PINMUX(9, 7, 7)>;     /* SSI0_SDATA */
     };
 };
 
@@ -469,42 +462,10 @@
 &rsci_i2c7 {
     pinctrl-0 = <&rsci_i2c7_pins>;
     pinctrl-names = "default";
-	#address-cells = <1>;
-	#size-cells = <0>;
+    #address-cells = <1>;
+    #size-cells = <0>;
 
-    status = "okay";
-
-    da7219: da7219@1a {
-        compatible = "dlg,da7219";
-
-        #sound-dai-cells = <0>;
-        #address-cells = <1>;
-        #size-cells = <0>;
-        reg = <0x1a>;
-
-        dlg,micbias-lvl = <2600>;
-        dlg,mic-amp-in-sel = "diff";
-
-        status = "okay";
-
-        interrupt-parent = <&pinctrl>;
-        interrupts = <RZV2H_GPIO(5, 1) IRQ_TYPE_LEVEL_LOW>;
-
-        da7219_aad {
-            dlg,adc-1bit-rpt = <1>;
-            dlg,btn-avg = <4>;
-            dlg,btn-cfg = <50>;
-            dlg,mic-det-thr = <500>;
-            dlg,jack-ins-deb = <20>;
-            dlg,jack-det-rate = "32_64";
-            dlg,jack-rem-deb = <1>;
-
-            dlg,a-d-btn-thr = <0xa>;
-            dlg,d-b-btn-thr = <0x16>;
-            dlg,b-c-btn-thr = <0x21>;
-            dlg,c-mic-btn-thr = <0x3E>;
-        };
-    };
+    status = "disabled";
 };
 
 &spi0 {
@@ -797,6 +758,7 @@
         #address-cells = <1>;
         #size-cells = <0>;
 
+        /* HDMI audio */
         rsnd_port0: port@0 {
             reg = <0>;
             rsnd_endpoint0: endpoint {

--- a/arch/arm64/boot/dts/renesas/rzv2h-rdk-ver1.dts
+++ b/arch/arm64/boot/dts/renesas/rzv2h-rdk-ver1.dts
@@ -238,8 +238,7 @@
 
         label = "rcar-sound";
 
-        dais = <&rsnd_port0	/* HDMI0  */
-            >;
+        dais = <&rsnd_port0>;
     };
 };
 
@@ -642,6 +641,7 @@
         v1p2-supply = <&reg_1p8v>;
 
         adi,dsi-lanes = <4>;
+        #sound-dai-cells = <0>;
 
         ports {
             #address-cells = <1>;
@@ -787,7 +787,8 @@
 
     /* audio_clkout */
     #clock-cells = <0>;
-    clock-frequency = <11289600>;
+    /* use internal clock, see rsnd_adg_get_clkout() */
+    clock-frequency = <22579200 24576000>;
 
     /* Multi DAI */
     #sound-dai-cells = <1>;

--- a/drivers/base/power/clock_ops.c
+++ b/drivers/base/power/clock_ops.c
@@ -147,6 +147,13 @@ static void pm_clk_op_unlock(struct pm_subsys_data *psd, unsigned long *flags)
 static inline void __pm_clk_enable(struct device *dev, struct pm_clock_entry *ce)
 {
 	int ret;
+	unsigned long rate = clk_get_rate(ce->clk);
+
+	if (!rate) {
+		dev_dbg(dev, "%s: clock %pC has 0 Hz rate, skipping enable\n",
+			__func__, ce->clk);
+		return;
+	}
 
 	switch (ce->status) {
 	case PCE_STATUS_ACQUIRED:

--- a/sound/soc/codecs/da7219.c
+++ b/sound/soc/codecs/da7219.c
@@ -2452,7 +2452,7 @@ static struct reg_sequence da7219_rev_aa_patch[] = {
 };
 
 static struct reg_sequence da7219_mic_enable_patch[] = {
-	{ DA7219_PLL_CTRL, 0x08 },
+	{ DA7219_PLL_CTRL, 0x88 },
 	{ DA7219_DAI_TDM_CTRL, 0x40 },
 	{ DA7219_MIXIN_L_GAIN, 0x0B },
 	{ DA7219_ADC_L_GAIN, 0x5F },


### PR DESCRIPTION
This PR includes:
- The RDK board fails to enable clka, likely due to hardware issues. This PR switches to using internal clocks for both HDMI and external audio codec. It supports two appropriate rates: 22579200 and 24576000, which are for 44.1kHz and 48kHz respectively.
- Remove the audio codec overlay and integrate DA7219 configuration directly into the main device tree. This enables dual audio support with both HDMI and external codec functionality.
- Prevent enabling clocks with zero rate in ASoC and clock_ops drivers.