### PR TITLE
arm64: dts: renesas: imdt-v2h-sbc: fix DRP-AI probe failure

### DIFF
--- a/arch/arm64/boot/dts/renesas/imdt-v2h-sbc.dts
+++ b/arch/arm64/boot/dts/renesas/imdt-v2h-sbc.dts
@@ -130,3 +130,8 @@
 &adc {
 	status = "okay";
 };
+
+&drpai0 {
+	memory-region = <&drp_reserved>;
+	status = "okay";
+};

--- a/arch/arm64/boot/dts/renesas/r9a09g057.dtsi
+++ b/arch/arm64/boot/dts/renesas/r9a09g057.dtsi
@@ -2850,6 +2850,19 @@
  			phy-names = "usb1";
  			status = "disabled";
  		};
+
+			drpai0: drpai@16800000 {
+				compatible = "renesas,rzv2h-drpai";
+				reg = <0 0x17000000 0 0x1000000>,
+				      <0 0x16800000 0 0x400000>;
+				interrupts = <GIC_SPI 914 IRQ_TYPE_LEVEL_HIGH>,
+				             <GIC_SPI 915 IRQ_TYPE_LEVEL_HIGH>,
+				             <GIC_SPI 916 IRQ_TYPE_LEVEL_HIGH>,
+				             <GIC_SPI 917 IRQ_TYPE_LEVEL_HIGH>;
+				resets = <&cpg 253>;
+				power-domains = <&cpg>;
+				status = "disabled";
+			};
 		rcar_sound: sound@13c00000 {
 			/*
 			 * #sound-dai-cells is required


### PR DESCRIPTION
arm64: dts: renesas: imdt-v2h-sbc: fix DRP-AI probe failure

Change includes:
        - Add memory-region = <&drp_reserved> to drpai node in imdt-v2h-sbc.dts
      and update r9a09g057.dtsi to resolve DRP-AI probe failure on IMDT V2H SBC board.