### PR TITLE
arm64: dts: renesas: split csi22/csi23 ar1335 camera into overlays

### DIFF
--- a/arch/arm64/boot/dts/renesas/imdt-v2-sbc.dtsi
+++ b/arch/arm64/boot/dts/renesas/imdt-v2-sbc.dtsi
@@ -849,7 +849,7 @@
 	pinctrl-0 = <&i2c5_pins>;
 	pinctrl-names = "default";
 	clock-frequency = <400000>;
-	status = "okay";
+	status = "disabled";
 
 	ar1335_csi23: camera@36 {
 		compatible = "onsemi,ar1335";
@@ -878,7 +878,7 @@
 	pinctrl-0 = <&i2c6_pins>;
 	pinctrl-names = "default";
 	clock-frequency = <400000>;
-	status = "okay";
+	status = "disabled";
 
 	ar1335_csi22: camera@36 {
 		compatible = "onsemi,ar1335";
@@ -954,77 +954,51 @@
 
 	ports {
 		port {
-		csi21_in: endpoint {
-			clock-lanes = <0>;
-			data-lanes = <1 2 3 4>;
-			remote-endpoint = <&ap1302_to_csi21>;
-		};
+			csi21_in: endpoint {
+				clock-lanes = <0>;
+				data-lanes = <1 2 3 4>;
+				remote-endpoint = <&ap1302_to_csi21>;
+			};
 		};
 	};
 };
 
 &csi22 {
-	status = "okay";
+	status = "disabled";
 
 	ports {
 		port@0 {
-			csi22_in: endpoint {
+			reg = <0>;
+				csi22_in: endpoint {
 				clock-lanes = <0>;
 				data-lanes  = <1 2 3 4>;
 				remote-endpoint = <&ar1335_to_csi22>;
-			};
-		};
-
-		port@1 {
-			csi22_out: endpoint {
-				remote-endpoint = <&cru22_in>;
 			};
 		};
 	};
 };
 
 &csi23 {
-	status = "okay";
+	status = "disabled";
 
 	ports {
 		port@0 {
+			reg = <0>;
 			csi23_in: endpoint {
 				clock-lanes = <0>;
 				data-lanes  = <1 2 3 4>;
 				remote-endpoint = <&ar1335_to_csi23>;
 			};
 		};
-
-		port@1 {
-			csi23_out: endpoint {
-				remote-endpoint = <&cru23_in>;
-			};
-		};
 	};
 };
 
 &cru2 {
-	status = "okay";
-
-	ports {
-		port@0 {
-			cru22_in: endpoint {
-				remote-endpoint = <&csi22_out>;
-			};
-		};
-	};
+	status = "disabled";
 };
 
 &cru3 {
-	status = "okay";
-
-	ports {
-		port@0 {
-			cru23_in: endpoint {
-				remote-endpoint = <&csi23_out>;
-			};
-		};
-	};
+	status = "disabled";
 };
 
 &xhci0 {

--- a/arch/arm64/boot/dts/renesas/imdt-v2h-sbc.dts
+++ b/arch/arm64/boot/dts/renesas/imdt-v2h-sbc.dts
@@ -119,14 +119,6 @@
 	status = "okay";
 };
 
-&cru2 {
-	status = "okay";
-};
-
-&cru3 {
-	status = "okay";
-};
-
 &adc {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/renesas/overlays/Makefile
+++ b/arch/arm64/boot/dts/renesas/overlays/Makefile
@@ -21,3 +21,5 @@ dtb-y += rzv2h-rdk-1.0-audio-codec.dtbo
 
 # IMDT-V2H-SBC overlays
 dtb-y += imdt-v2h-sbc-1.0-dsi.dtbo
+dtb-y += imdt-v2h-sbc-1.0-cru-csi22-ar1335.dtbo
+dtb-y += imdt-v2h-sbc-1.0-cru-csi23-ar1335.dtbo

--- a/arch/arm64/boot/dts/renesas/overlays/imdt-v2h-sbc-1.0-cru-csi22-ar1335.dts
+++ b/arch/arm64/boot/dts/renesas/overlays/imdt-v2h-sbc-1.0-cru-csi22-ar1335.dts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Device Tree Overlay for CSI2-2 AR1335 on IMDT-V2H-SBC
+ * Copyright (C) 2026 Renesas Electronics Corporation
+ */
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+
+&i2c6 {
+	status = "okay";
+};
+
+&csi22 {
+	status = "okay";
+};
+
+&cru2 {
+	status = "okay";
+};
+
+&cam_gpio {
+	ccm-dis-hog-csi2 {
+		gpio-hog;
+		gpios = <2 GPIO_ACTIVE_LOW>;
+		output-high;
+	};
+};

--- a/arch/arm64/boot/dts/renesas/overlays/imdt-v2h-sbc-1.0-cru-csi23-ar1335.dts
+++ b/arch/arm64/boot/dts/renesas/overlays/imdt-v2h-sbc-1.0-cru-csi23-ar1335.dts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Device Tree Overlay for CSI2-3 AR1335 on IMDT-V2H-SBC
+ * Copyright (C) 2026 Renesas Electronics Corporation
+ */
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+
+&i2c5 {
+	status = "okay";
+};
+
+&csi23 {
+	status = "okay";
+};
+
+&cru3 {
+	status = "okay";
+};
+
+&cam_gpio {
+	ccm-dis-hog-csi3 {
+		gpio-hog;
+		gpios = <3 GPIO_ACTIVE_LOW>;
+		output-high;
+	};
+};


### PR DESCRIPTION
Move ar1335 camera configuration for csi22 (i2c6) and csi23 (i2c5) from base DTS into separate device tree overlays. This allows the camera pipelines to be loaded optionally at boot time.

Add two overlay files:
- imdt-v2h-sbc-1.0-cru-csi2-ar1335.dts (csi22, i2c6)
- imdt-v2h-sbc-1.0-cru-csi3-ar1335.dts (csi23, i2c5)