### PR TITLE
arm64: dts: renesas: rz-cmn: add firmware/optee DT nodes for OP-TEE driver

### DIFF
--- a/arch/arm64/boot/dts/renesas/r9a07g044.dtsi
+++ b/arch/arm64/boot/dts/renesas/r9a07g044.dtsi
@@ -113,6 +113,13 @@
 		};
 	};
 
+	firmware {
+		optee {
+			compatible = "linaro,optee-tz";
+			method = "smc";
+		};
+	};
+
 	gpu_opp_table: opp-table-1 {
 		compatible = "operating-points-v2";
 

--- a/arch/arm64/boot/dts/renesas/r9a07g054.dtsi
+++ b/arch/arm64/boot/dts/renesas/r9a07g054.dtsi
@@ -113,6 +113,13 @@
 		};
 	};
 
+	firmware {
+		optee {
+			compatible = "linaro,optee-tz";
+			method = "smc";
+		};
+	};
+
 	gpu_opp_table: opp-table-1 {
 		compatible = "operating-points-v2";
 

--- a/arch/arm64/boot/dts/renesas/r9a09g057.dtsi
+++ b/arch/arm64/boot/dts/renesas/r9a09g057.dtsi
@@ -25,6 +25,13 @@
 		 i2c8 = &i2c8;
 	};
 
+	firmware {
+		optee {
+			compatible = "linaro,optee-tz";
+			method = "smc";
+		};
+	};
+
 	audio_extal_clk: audio-extal-clk {
 		compatible = "fixed-clock";
 		#clock-cells = <0>;


### PR DESCRIPTION
Add the `firmware/optee` DT node to all 7 rz-cmn boards so the Linux OP-TEE driver (`drivers/tee/optee/smc_abi.c`) can probe and create `/dev/tee0`.