### PR TITLE
arm64: dts: renesas: Add SPDX license identifier and copyright

### DIFF
--- a/arch/arm64/boot/dts/renesas/imdt-v2h-sbc.dts
+++ b/arch/arm64/boot/dts/renesas/imdt-v2h-sbc.dts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/*
+* Device Tree Source for the IMDT-V2H SBC
+*
+* Copyright (C) 2026 Renesas Electronics Corp.
+*/
+
 /dts-v1/;
 #include "r9a09g057.dtsi"
 #include <dt-bindings/pinctrl/rzv2h-pinctrl.h>

--- a/arch/arm64/boot/dts/renesas/overlays/imdt-v2h-sbc-1.0-dsi.dts
+++ b/arch/arm64/boot/dts/renesas/overlays/imdt-v2h-sbc-1.0-dsi.dts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/*
+* Device Tree Overlay for DSI panel on IMDT-V2H SBC
+*
+* Copyright (C) 2026 Renesas Electronics Corp.
+*/
+
 /dts-v1/;
 /plugin/;
 


### PR DESCRIPTION
Add the SPDX license identifier and Renesas copyright header to the IMDT-V2H SBC device tree source and its DSI panel overlay, in line with kernel licensing conventions.