### PR TITLE
Quoctrinh rz cmn 3.4 update

### DIFF
--- a/arch/arm64/boot/dts/renesas/r8a779g0.dtsi
+++ b/arch/arm64/boot/dts/renesas/r8a779g0.dtsi
@@ -2128,6 +2128,15 @@
 			interrupts = <GIC_PPI 9 IRQ_TYPE_LEVEL_HIGH>;
 		};
 
+		gsx: gsx@fd000000 {
+			compatible = "renesas,gsx";
+			reg = <0 0xfd000000 0 0x800000>;
+			interrupts = <GIC_SPI 464 IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&cpg CPG_MOD 0>;
+			power-domains = <&sysc R8A779G0_PD_A23DGB>;
+			resets = <&cpg 0>;
+		};
+
 		csi40: csi2@fe500000 {
 			compatible = "renesas,r8a779g0-csi2";
 			reg = <0 0xfe500000 0 0x40000>;

--- a/arch/arm64/boot/dts/renesas/r8a779g3-sparrow-hawk.dts
+++ b/arch/arm64/boot/dts/renesas/r8a779g3-sparrow-hawk.dts
@@ -199,6 +199,13 @@
 		gpios-states = <1>;
 		states = <1800000 0>, <3300000 1>;
 	};
+
+	firmware {
+		optee {
+			compatible = "linaro,optee-tz";
+			method = "smc";
+		};
+	};
 };
 
 /* Use thermal-idle cooling for all SoC cores */


### PR DESCRIPTION
- Describe the OP-TEE secure-world firmware interface for Sparrow-Hawk so Linux can bind the OP-TEE SMC driver when the secure payload is running.
- Describe the R-Car V4H GSX block so the PowerVR kernel driver can bind to its register range and interrupt.